### PR TITLE
Fix various typos

### DIFF
--- a/README
+++ b/README
@@ -68,7 +68,7 @@ the 'sample view'.
 
 In the sample view there is a grey vertical bar called the 'cursor'. The cursor 
 follows the sound wave when you play the sound. You can position the cursor by 
-clicking with the right (2:nd) mouse button. If you do this while you're 
+clicking with the right (2nd) mouse button. If you do this while you're 
 playing a file, the playing will continue from the new cursor position. You can 
 also position the cursor more exact by using the 'Position Cursor...' command 
 on the Edit menu.
@@ -177,7 +177,7 @@ simple amplification of the sound.
 
    This converts the samplerate of the entire file to one you specify. There 
 are different methods for doing this, usually the one in the top has the best 
-quality but can take longer than the other methode.
+quality but can take longer than the other method.
 
  * Convert sample format...
 

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -729,7 +729,7 @@ Chunk *chunk_mix(Chunk *c1, Chunk *c2, int dither_mode, StatusBar *bar)
 	  m = c;
      }
 
-     /* Warn if clipping occured */
+     /* Warn if clipping occurred */
      if (clipcount > 0) {
 	  if (clipcount > 1000000000) clipcount = 1000000000;
 	  str = g_strdup_printf(_("The mixed result was clipped %d times."),
@@ -857,7 +857,7 @@ static Chunk *chunk_sandwich_main(Chunk *c1, Chunk *c2, int dither_mode, StatusB
      g_free(outbuf);
      if (!m) return NULL;
 
-     /* Warn if clipping occured */
+     /* Warn if clipping occurred */
      clipwarn(clipcount,FALSE);
 
      return m;

--- a/src/document.c
+++ b/src/document.c
@@ -294,7 +294,7 @@ void document_play(Document *d, off_t start, off_t end, gboolean loop,
      
      g_assert(d != NULL);
      /* This special if case was introduced to avoid a skipping sound
-      * caused by the cursor not matching the actual playing positon when
+      * caused by the cursor not matching the actual playing position when
       * pressing the "play" button and you're already playing. This
       * becomes a "wobbling" sound when holding down the ',' key due
       * to the keyboard auto-repeating. */

--- a/src/help.c
+++ b/src/help.c
@@ -31,7 +31,7 @@ static const char * D01_contents[] = {
      "\n",
      N_("The area where you 'see' the contents of the file you are editing, is called the 'sample view'. \n"),
      "\n",
-     N_("In the sample view there is a grey vertical bar called the 'cursor'. The cursor follows the sound wave when you play the sound. You can position the cursor by clicking with the right (2:nd) mouse button. If you do this while you're playing a file, the playing will continue from the new cursor position. You can also position the cursor more exact by using the 'Position Cursor...' command on the Edit menu.\n"),
+     N_("In the sample view there is a grey vertical bar called the 'cursor'. The cursor follows the sound wave when you play the sound. You can position the cursor by clicking with the right (2nd) mouse button. If you do this while you're playing a file, the playing will continue from the new cursor position. You can also position the cursor more exact by using the 'Position Cursor...' command on the Edit menu.\n"),
      "\n",
      N_("You can place marks in your file by holding down Ctrl and pressing a number from 0 to 9. This will place a mark (green vertical bar) with the same number at the current cursor position. You can later make the cursor go to that position again by just pressing the number. Setting and jumping to marks can be done while playing. To remove a mark, jump to the mark and set it again.\n"),
      NULL };
@@ -98,7 +98,7 @@ static const char * D05_contents[] = {
      "\n",
      N_(" * Convert samplerate...\n"),
      "\n",
-     N_("   This converts the samplerate of the entire file to one you specify. There are different methods for doing this, usually the one in the top has the best quality but can take longer than the other methode.\n"),
+     N_("   This converts the samplerate of the entire file to one you specify. There are different methods for doing this, usually the one in the top has the best quality but can take longer than the other method.\n"),
      "\n",
      N_(" * Convert sample format...\n"),
      "\n",

--- a/src/inifile.h
+++ b/src/inifile.h
@@ -73,7 +73,7 @@ void inifile_init(void);
 gchar *inifile_get(gchar *setting, gchar *defaultValue);
 
 
-/* Same as inifile_get excepts requires that the value is a guint32 value.
+/* Same as inifile_get except requires that the value is a guint32 value.
  * Returns: The value converted into a guint32 or defaultValue if setting 
  * doesn't exist or is not a valid number.
  */

--- a/src/listobject.h
+++ b/src/listobject.h
@@ -53,7 +53,7 @@ GType list_object_get_type(void);
 
 
 /* Creates a new ListObject 
- * do_ref: Enable automatic referencing/derefencing - should only be used
+ * do_ref: Enable automatic referencing/dereferencing - should only be used
  *         if the list just contains GtkObjects  */
 ListObject *list_object_new(gboolean do_ref);
 

--- a/src/main.c
+++ b/src/main.c
@@ -719,7 +719,7 @@ static const gint smallsizes_30fps[] = { 30, 10, 5 };
  * 0 - Both major and minor points should have text from the get_time_head 
  *     function.
  * 1 - Major points should have text from the get_time_head function, and 
- *     minor points should have text from teh get_time_tail function.
+ *     minor points should have text from the get_time_tail function.
  */ 
 
 /* Midpoints are generated when there is a minor point scale that has

--- a/src/rateest.h
+++ b/src/rateest.h
@@ -21,7 +21,7 @@
 
 /* Code for "guessing" the real sample rate and total buffer size
  * without using any special sound driver calls, by logging time
- * and size of succesful writes. */
+ * and size of successful writes. */
 
 #ifndef RATEEST_H_INCLUDED
 #define RATEEST_H_INCLUDED

--- a/src/sound-pulse.c
+++ b/src/sound-pulse.c
@@ -866,7 +866,7 @@ static void pulse_source_info_cb(pa_context *c, const pa_source_info *i,
  * Perform a quite messy workaround, ifdef:d with the
  * DEFUALT_SOURCE_BROKEN macro */
 
-/* Becuase PA didn't introduce PA_MAJOR/MINOR/MICRO macros until 0.9.15, 
+/* Because PA didn't introduce PA_MAJOR/MINOR/MICRO macros until 0.9.15, 
  * this will have to be done for the older versions as well... */
 #define DEFAULT_SOURCE_BROKEN
 
@@ -992,7 +992,7 @@ static void pulse_input_store(Ringbuf *buf)
      size_t b;
 
      if (pulse_data.overflow_report_count < pulse_data.overflow_count) {
-	  console_message("Overrun occured!");
+	  console_message("Overrun occurred!");
 	  pulse_data.overflow_report_count = pulse_data.overflow_count;
      }
 

--- a/src/sound.h
+++ b/src/sound.h
@@ -34,7 +34,7 @@
    2. Idle
    3. Playing (or waiting for output)
    4. Recording
-   5. Quitted (ending state)
+   5. Quitting (ending state)
 */
 
 /* Global variable for selecting whether the sound driver should "lock" itself
@@ -140,7 +140,7 @@ void sound_init(void);
 gint sound_poll(void);
 
 /* Sound module cleanup.
- * Changes state to state 5 (Quitted)
+ * Changes state to state 5 (Quitting)
  */
 
 void sound_quit(void);


### PR DESCRIPTION
Found via ` codespell -q 3 -S *.po,*.pot,./ChangeLog`